### PR TITLE
Improve build setup

### DIFF
--- a/FilamentSDL/CMakeLists.txt
+++ b/FilamentSDL/CMakeLists.txt
@@ -14,8 +14,13 @@ set(SRC
         input.cpp
         renderer.cpp
         camera_controller.cpp
-        native_window_helper_cocoa.mm
 )
+
+if(APPLE)
+    list(APPEND SRC native_window_helper_cocoa.mm)
+else()
+    list(APPEND SRC native_window_helper.cpp)
+endif()
 
 add_executable(filament_sdl ${SRC})
 
@@ -29,15 +34,21 @@ target_link_libraries(filament_sdl PRIVATE
         filament
 )
 
-# Material compilation
-set(MATERIAL_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/materials)
-file(MAKE_DIRECTORY ${MATERIAL_OUTPUT_DIR})
-add_custom_command(
-        OUTPUT ${MATERIAL_OUTPUT_DIR}/lit_color.filamat
-        COMMAND ${CMAKE_SOURCE_DIR}/../third_party/filament/bin/matc -o ${MATERIAL_OUTPUT_DIR}/lit_color.filamat
-        ${CMAKE_CURRENT_SOURCE_DIR}/materials/lit_color.mat
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/materials/lit_color.mat
-        COMMENT "Compiling Filament material"
-)
-add_custom_target(materials ALL DEPENDS ${MATERIAL_OUTPUT_DIR}/lit_color.filamat)
-add_dependencies(filament_sdl materials)
+if(TARGET SDL2::SDL2main)
+    target_link_libraries(filament_sdl PRIVATE SDL2::SDL2main)
+endif()
+
+# Material compilation (only available on macOS where prebuilt tools are provided)
+if(APPLE)
+    set(MATERIAL_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/materials)
+    file(MAKE_DIRECTORY ${MATERIAL_OUTPUT_DIR})
+    add_custom_command(
+            OUTPUT ${MATERIAL_OUTPUT_DIR}/lit_color.filamat
+            COMMAND ${CMAKE_SOURCE_DIR}/../third_party/filament/bin/matc -o ${MATERIAL_OUTPUT_DIR}/lit_color.filamat
+            ${CMAKE_CURRENT_SOURCE_DIR}/Materials/lit_color.mat
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Materials/lit_color.mat
+            COMMENT "Compiling Filament material"
+    )
+    add_custom_target(materials ALL DEPENDS ${MATERIAL_OUTPUT_DIR}/lit_color.filamat)
+    add_dependencies(filament_sdl materials)
+endif()

--- a/FilamentSDL/native_window_helper.cpp
+++ b/FilamentSDL/native_window_helper.cpp
@@ -1,0 +1,17 @@
+#include "native_window_helper.h"
+#include <SDL_syswm.h>
+
+void* GetNativeWindow(SDL_Window* window) {
+    SDL_SysWMinfo info;
+    SDL_VERSION(&info.version);
+    if (!SDL_GetWindowWMInfo(window, &info)) {
+        return nullptr;
+    }
+#if defined(__linux__)
+    return (void*)info.info.x11.window;
+#elif defined(_WIN32)
+    return (void*)info.info.win.window;
+#else
+    return nullptr;
+#endif
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Install required packages depending on the platform
+if command -v apt-get >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential cmake libsdl2-dev
+elif command -v brew >/dev/null; then
+    brew install cmake sdl2
+elif command -v pacman >/dev/null; then
+    sudo pacman -Sy --noconfirm cmake sdl2
+else
+    echo "Please install CMake and SDL2 development files using your package manager" >&2
+fi
+
+# Build project
+mkdir -p FilamentSDL/build
+cmake -S FilamentSDL -B FilamentSDL/build
+cmake --build FilamentSDL/build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu)

--- a/third_party/filament/CMakeLists.txt
+++ b/third_party/filament/CMakeLists.txt
@@ -2,9 +2,19 @@ cmake_minimum_required(VERSION 3.13)
 project(filament LANGUAGES CXX)
 
 # 1) coleta todos os .a numa lista
-file(GLOB_RECURSE FILAMENT_LIBS
-        "${CMAKE_CURRENT_SOURCE_DIR}/macos/arm64/*.a"
-)
+if(APPLE)
+    file(GLOB_RECURSE FILAMENT_LIBS
+            "${CMAKE_CURRENT_SOURCE_DIR}/macos/arm64/*.a"
+    )
+elseif(UNIX)
+    file(GLOB_RECURSE FILAMENT_LIBS
+            "${CMAKE_CURRENT_SOURCE_DIR}/linux/x86_64/*.a"
+    )
+elseif(WIN32)
+    message(FATAL_ERROR "Precompiled Filament libraries for Windows are not shipped with this repository")
+else()
+    message(FATAL_ERROR "Unsupported platform for Filament binaries")
+endif()
 
 # 2) cria um target de INTERFACE (não precisa ter um .a único)
 add_library(filament INTERFACE)


### PR DESCRIPTION
## Summary
- make the setup script work with multiple package managers
- link to SDL2::SDL2main if available
- add platform checks for Filament libraries
- build Filament materials only on macOS

## Testing
- `bash setup.sh` *(fails: incompatible prebuilt matc binary)*

------
https://chatgpt.com/codex/tasks/task_e_68575f7f7fe4832993cb885b7c3e3142